### PR TITLE
Changing lambda module to pull from Terraform registry

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,8 @@ resource "aws_iam_policy" "main" {
 
 # Lambda function
 module "amiclean_lambda" {
-  source = "github.com/trussworks/terraform-aws-lambda"
+  source  = "trussworks/lambda/aws"
+  version = "~>1.0.0"
 
   name                   = "${local.name}"
   job_identifier         = "${var.job_identifier}"


### PR DESCRIPTION
Now that I've confirmed that the lambda module is working right and it's been added to the Terraform registry, want to change the source of this and lock it to a version.