### PR TITLE
Fixing log retention variable passing to lambda module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -97,11 +97,12 @@ module "amiclean_lambda" {
   source  = "trussworks/lambda/aws"
   version = "~>1.0.0"
 
-  name                   = "${local.name}"
-  job_identifier         = "${var.job_identifier}"
-  runtime                = "go1.x"
-  role_policy_arns_count = 1
-  role_policy_arns       = ["${aws_iam_policy.main.arn}"]
+  name                           = "${local.name}"
+  job_identifier                 = "${var.job_identifier}"
+  runtime                        = "go1.x"
+  role_policy_arns_count         = 1
+  role_policy_arns               = ["${aws_iam_policy.main.arn}"]
+  cloudwatch_logs_retention_days = "${var.cloudwatch_logs_retention_days}"
 
   s3_bucket = "${var.s3_bucket}"
   s3_key    = "${local.pkg}/${var.version_to_deploy}/${local.pkg}.zip"


### PR DESCRIPTION
Well, I figured out the mystery of why logs were getting switched to 30 day retention -- this module wasn't passing the cloudwatch logs retention variable to the lambda module. This should fix that.