### PR TITLE
Increase version of lambda module from ~>2.0.0 to ~>2.4.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,7 +66,7 @@ resource "aws_iam_policy" "main" {
 # Lambda function
 module "amiclean_lambda" {
   source  = "trussworks/lambda/aws"
-  version = "~>2.0.0"
+  version = "~>2.4.0"
 
   name                           = local.name
   job_identifier                 = var.job_identifier


### PR DESCRIPTION
This resolves lots of warnings when using terraform 0.14